### PR TITLE
Refine cypress tests to have two describe blocks

### DIFF
--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -1,38 +1,55 @@
-describe('Rancid Tomatillos see movie info flow', () => {
+describe('Main Page', () => {
   beforeEach(() => {
     cy.intercept("GET", "https://rancid-tomatillos.herokuapp.com/api/v2/movies", {
       statusCode: 200,
       fixture: "testData"
     })
-      .visit("http://localhost:3000/")
+  .visit("http://localhost:3000/")
   });
   it("should be able to visit page", () => {
     cy.contains("Rancid Tomatillos").get("h1");
   });
   it("should be able to render movies", () => {
-    cy.get("section")
+    cy.get("section").first()
       .contains('Black Adam')
       .contains('4.0')
       .get("img[src='https://image.tmdb.org/t/p/original//pFlaoHTZeyNkG83vxsAJiGzfSsa.jpg']")
 
-    cy.get("section")
-      .contains("The Woman King")
-      .contains("4.0")
+    cy.get("section").last()
+      .contains("X")
+      .get("p")
+      .contains('1.0')
       .get(
-        "img[src='https://image.tmdb.org/t/p/original//438QXt1E3WJWb3PqNniK0tAE5c1.jpg']"
+        "img[src='https://image.tmdb.org/t/p/original//woTQx9Q4b8aO13jR9dsj8C9JESy.jpg']"
       );
+  });
+  it('should display a 500 error when the server is down', () => {
+    cy.intercept("https://rancid-tomatillos.herokuapp.com/api/v2/movies", {forceNetworkError: true})
+    cy.visit("http://localhost:3000/")
+    cy.get("h1")
+    cy.contains("500 Error! Try again later!")
+  })
+});
+describe('Movie Detail Page', () => {
+  beforeEach(() => {
+    cy.intercept("GET", "https://rancid-tomatillos.herokuapp.com/api/v2/movies", {
+      statusCode: 200,
+      fixture: "testData"
+    })
+  .visit("http://localhost:3000/")
   });
   it("should be able to display the info a particular movie when clicked", () => {
     cy.intercept("GET", "http://localhost:3000/436270", {
       statusCode: 200,
       fixture: "testData",
     });
-    cy.get("section").contains("Black Adam").click();
+    cy.get("h3").first()
+    .contains("Black Adam").click();
     cy.get(
       "img[src='https://image.tmdb.org/t/p/original//pFlaoHTZeyNkG83vxsAJiGzfSsa.jpg']"
     );
     cy.get("h3").contains("Title: Black Adam")
-    cy.get("p").contains("Average Rating: 4.0")
+    cy.get("p").contains("Average Rating: 4")
     cy.get("p").contains("Release Date: 2022-10-19")
   })
   it("should be able to go back to the home page", () => {
@@ -52,9 +69,3 @@ describe('Rancid Tomatillos see movie info flow', () => {
       );
   })
 });
-
-
-
-
-
-

--- a/cypress/fixtures/testData.json
+++ b/cypress/fixtures/testData.json
@@ -23,6 +23,14 @@
       "title": "R.I.P.D. 2: Rise of the Damned",
       "average_rating": 7,
       "release_date": "2022-11-15"
-    }
+    },
+    {
+      "id": 760104,
+      "poster_path": "https://image.tmdb.org/t/p/original//woTQx9Q4b8aO13jR9dsj8C9JESy.jpg",
+      "backdrop_path": "https://image.tmdb.org/t/p/original//70Rm9ItxKuEKN8iu6rNjfwAYUCJ.jpg",
+      "title": "X",
+      "average_rating": 1,
+      "release_date": "2022-03-17"
+      }
   ]
 }


### PR DESCRIPTION
# Description
- Refine cypress tests to have two describe blocks
- Add new test for 500 error
# Contributors
@ben-rosner-williamsburg 
# Checklist
- [x] My PR has an appropriately descriptive and concise title.
- [x] My PR has a clear description of all proposed changes.
- [x] My PR denotes any/all team members who contributed to it.
- [x] My code follows the Turing Style Guides and best practices.
- [x] I ran the code locally and verified that there are no visible errors.
- [x] feat: My code is clean and readable, so my teammates can easily review it.

# Notes
